### PR TITLE
Email Preview Text

### DIFF
--- a/app/assets/stylesheets/email.scss
+++ b/app/assets/stylesheets/email.scss
@@ -98,6 +98,14 @@ h3 {
 // ==========================
 // Header
 // ==========================
+.preheader {
+  display: none !important;
+  visibility: hidden !important;
+}
+
+// ==========================
+// Header
+// ==========================
 .header {
   display: block;
   padding: 30px;

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,3 +1,5 @@
+<%= render 'shared/email_header', preheader: 'You can confirm your account email through the link enclosed. To report any issues or for general inquiries email us at hello@eruditionapp.com. Erudition App, Inc. 520 Chestnut St, Philadelphia, PA 19106' %>
+
 <table class="section">
   <tr>
     <td>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,5 @@
+<%= render 'shared/email_header', preheader: 'We&#39;re contacting you to notify you that your password has been changed. To report any issues or for general inquiries email us at hello@eruditionapp.com. Erudition App, Inc. 520 Chestnut St, Philadelphia, PA 19106' %>
+
 <table class="section">
   <tr>
     <td>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,3 +1,5 @@
+<%= render 'shared/email_header', preheader: 'Someone has requested a link to change your password. You can do this through the link enclosed. To report any issues or for general inquiries email us at hello@eruditionapp.com. Erudition App, Inc. 520 Chestnut St, Philadelphia, PA 19106' %>
+
 <table class="section">
   <tr>
     <td>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,3 +1,5 @@
+<%= render 'shared/email_header', preheader: 'Yout account has been locked due to an excessive number of unsuccessful sign in attempts. Click the link enclosed to unlock your account. To report any issues or for general inquiries email us at hello@eruditionapp.com. Erudition App, Inc. 520 Chestnut St, Philadelphia, PA 19106' %>
+
 <table class="section">
   <tr>
     <td>

--- a/app/views/layouts/email.html.erb
+++ b/app/views/layouts/email.html.erb
@@ -10,8 +10,6 @@
       <tr>
         <td>
 
-          <%= render "shared/email_header" %>
-
           <%= yield %>
 
           <%= render "shared/email_footer" %>

--- a/app/views/shared/_email_header.html.erb
+++ b/app/views/shared/_email_header.html.erb
@@ -1,3 +1,10 @@
+<table class="preheader">
+  <tr>
+    <td>
+      <%= preheader %>
+    </td>
+  </tr>
+</table>
 <table class="header">
   <tr>
     <td>


### PR DESCRIPTION
@findandrew Tested on staging and seems to fix #5. I added supplementary text to help fill the preview character limit and prevent the `logo-black`src from displaying. We can tweak the copy down the line ... consider this cache _busted_
